### PR TITLE
fix: assign firebase admin app to instance when already initialized

### DIFF
--- a/packages/firebase-server/index/src/index.ts
+++ b/packages/firebase-server/index/src/index.ts
@@ -1,6 +1,6 @@
 import admin from "firebase-admin";
 import { Throwable, getErrorMessage, isSSR } from "@ouellettec/utils";
-import { App as FirebaseAdminApp } from "firebase-admin/app";
+import { App as FirebaseAdminApp, getApp } from "firebase-admin/app";
 
 export type FirebaseAdminConfig = {
   projectId: string;


### PR DESCRIPTION
fix: assign firebase admin app to instance when already initialized #44